### PR TITLE
Added support for javascript codes (node compiler and node runner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ cftool get 600 # Download inputs and outputs for all problems on contest 600.
 cftool compile code.cc # Compile code.cc using g++.
 cftool compile -l c++11 code.cc  # Compile code.cc with g++ 11.
 cftool compile code.py # nothing will happen.
+cftool compile code.js # nothing will happen.
 ```
 
 ### test
@@ -59,3 +60,5 @@ To get full list of available commands run cftool with --help flag.
 
 # License
 MIT
+# Notes
+- Node support is experimental. The readline function is simplified version from 'sget' package.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cftool": "./src/cftool.js"
   },
   "scripts": {
-    "test": "mocha test"
+    "test": "mocha"
   },
   "repository": {
     "url": "https://github.com/guilhermeleobas/cftool"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "get codeforces inputs and outputs for a specific problem",
   "main": "index.js",
   "dependencies": {
+    "bluebird": "^3.3.5",
     "chalk": "^1.1.1",
     "cheerio": "^0.19.0",
     "commander": "*",

--- a/src/cftool.js
+++ b/src/cftool.js
@@ -69,10 +69,10 @@ function loadInputsAndOutputs (problem){
   
     for (let i in data){
       if (data[i] === '') continue;
-      else if (data[i].indexOf('in') === -1){
+      else if (/.*\d+.out$/.test(data[i])){
         ret.out.push (problem + '/' + data[i]);
       }
-      else {
+      else if (/.*\d+.in$/.test(data[i])){
         ret.in.push (problem + '/' + data[i]); 
       }
     }

--- a/src/compile.js
+++ b/src/compile.js
@@ -12,6 +12,7 @@ var mapLanguages = {
   "cc": "c++",
   "py": "python",
   "java": "java",
+  "js": "node",
   "": ""
 };
 
@@ -21,6 +22,7 @@ var compileCommand = {
   "c++": "g++ %s -o main",
   "c++11": "g++ -std=c++11 %s -o main",
   "python": "",
+  "node": "",
   "python3": ""
 };
 

--- a/src/format.js
+++ b/src/format.js
@@ -61,6 +61,13 @@ exports.formatOutput = function (userOutput, correctOutput, testCase, diffStatus
       s += sep + endl;
     }
 
+    if (typeof userOutput.stderr !== "undefined" && userOutput.stderr.length > 0) {
+      s += colorFormat ("Standard error", gray, useColors) + endl;
+      s += sep + endl;
+      s += colorFormat (userOutput.stderr, red, useColors) + endl;
+      s += sep + endl;
+    }
+
   }
 
   return s;

--- a/src/run.js
+++ b/src/run.js
@@ -9,7 +9,7 @@ var runCommand = {
   "c": "./main",
   "c++": "./main",
   "python": "python %s",
-  "node": "node -e \"readline=function(){var n=require('fs');require('readline');return win32=function(){return'win32'===process.platform},readSync=function(r){var e=win32()?process.stdin.fd:n.openSync('/dev/stdin','rs'),t=n.readSync(e,r,0,r.length);return win32()||n.closeSync(e),t},function(n){try{return n.toString(null,0,readSync(n))}catch(r){throw r}}(new Buffer(256))};print=console.log;console.log=function(){};write=process.stdout.write;require('./%s')\"",
+  "node": "node -e \"readline=function(){var n=require('fs');require('readline');return win32=function(){return'win32'===process.platform},readSync=function(r){var e=win32()?process.stdin.fd:n.openSync('/dev/stdin','rs'),t=n.readSync(e,r,0,r.length);return win32()||n.closeSync(e),t},function(n){return n.toString(null,0,readSync(n)).replace('\\n','').replace('\\r','')}(new Buffer(256))};print=console.log;console.log=function(){};write=process.stdout.write;require('./%s')\"",
   "python3": "python3 %s"
 };
 

--- a/src/run.js
+++ b/src/run.js
@@ -4,12 +4,13 @@ var util = require ('util');
 var child_process = require ('child_process');
 var ms = require ('./ms.js');
 var Promise = require ('bluebird');
+var fs = require('fs');
 
 var runCommand = {
   "c": "./main",
   "c++": "./main",
   "python": "python %s",
-  "node": "node -e \"readline=function(){var n=require('fs');require('readline');return win32=function(){return'win32'===process.platform},readSync=function(r){var e=win32()?process.stdin.fd:n.openSync('/dev/stdin','rs'),t=n.readSync(e,r,0,r.length);return win32()||n.closeSync(e),t},function(n){return n.toString(null,0,readSync(n)).replace('\\n','').replace('\\r','')}(new Buffer(256))};print=console.log;console.log=function(){};write=process.stdout.write;require('./%s')\"",
+  "node": "node -e \"" + fs.readFileSync(__dirname + "/wrapper.js").toString().replace("\n","").replace("\\","\\\\") + ";require('./%s')\"",
   "python3": "python3 %s"
 };
 

--- a/src/run.js
+++ b/src/run.js
@@ -9,6 +9,7 @@ var runCommand = {
   "c": "./main",
   "c++": "./main",
   "python": "python %s",
+  "node": "node -e \"readline=function(){var n=require('fs');require('readline');return win32=function(){return'win32'===process.platform},readSync=function(r){var e=win32()?process.stdin.fd:n.openSync('/dev/stdin','rs'),t=n.readSync(e,r,0,r.length);return win32()||n.closeSync(e),t},function(n){try{return n.toString(null,0,readSync(n))}catch(r){throw r}}(new Buffer(256))};print=console.log;console.log=function(){};write=process.stdout.write;require('./%s')\"",
   "python3": "python3 %s"
 };
 

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -1,0 +1,32 @@
+function readline() {
+  fs = require('fs');
+  win32 = function() {
+    return ('win32' === process.platform);
+  },
+  readSync = function() {
+    var fd = win32() ? process.stdin.fd : fs.openSync('/dev/stdin', 'rs');
+    var ret = '';
+    buffer = new Buffer(1);
+    var started = false;
+    while (true) {
+      var bytes = fs.readSync(fd, buffer, 0, 1);
+      
+      if (bytes == 0)
+        break;
+      var chr = String.fromCharCode(buffer[0]);
+      if (buffer[0] == 0x0a || buffer[0] == 0x0d) {
+        if (started)
+          break;
+      } else {
+        started = true;
+        ret += chr;
+      }
+    }
+    if (!win32()) fs.closeSync(fd);
+    return ret;
+  };
+  return readSync();
+}
+print=console.log;
+console.log=console.error;
+write=process.stdout.write;

--- a/test/source_code/echo.cpp
+++ b/test/source_code/echo.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+using namespace std;
+
+int main () {
+  string in;
+  getline(cin, in);
+  cout << in << endl;
+}

--- a/test/source_code/echo.js
+++ b/test/source_code/echo.js
@@ -1,0 +1,1 @@
+print(readline());

--- a/test/source_code/echo3.js
+++ b/test/source_code/echo3.js
@@ -1,0 +1,3 @@
+print(readline());
+print(readline());
+print(readline());

--- a/test/testCompile.js
+++ b/test/testCompile.js
@@ -36,6 +36,7 @@ describe ('Detect language', function (){
 
 describe ('Compile a program', function (){
   it ('should compile goodcpp.cc', function (done){
+    this.slow(5000);
     compile.compile("test/source_code/goodcpp.cc", null).then( function (output){
 
       expect (output).to.have.property('exec');
@@ -48,6 +49,7 @@ describe ('Compile a program', function (){
   });
 
   it ('should compile goodcpp2.cc', function (done){
+    this.slow(5000);
     compile.compile("test/source_code/goodcpp2.cc", "c++11").then( function (output){
 
       expect (output).to.have.property('exec');

--- a/test/testRun.js
+++ b/test/testRun.js
@@ -1,30 +1,76 @@
 var chai = require ('chai');
 var expect = require ('chai').expect;
 var run = require ('./../src/run.js');
+var compile = require ('./../src/compile.js');
 var execSync = require ('child_process').execSync;
+
+function testRun(output, testStr, done) {
+
+  try {
+    expect (output).to.have.property('stdout', testStr + "\n");
+    expect (output).to.have.property('status', 'ok');
+    expect (output).to.have.property('time');
+    expect (output.time).to.contains('ms');
+    done();
+  } catch(err) {
+    done(output.err);
+  }
+
+}
 
 describe ('test run command', function (){
   
   before (function (){
     execSync('echo \'teste1\' > teste1.txt');
     execSync('echo \'a sentence lorem ipsum\' > teste2.txt');
-    execSync('echo \'pong\' > teste3.txt');
+    execSync('echo \'pong\\npong\\npong\' > teste3.txt');
+    compile.compile("test/source_code/echo.cpp", "c++");
   });
   
-  it ('should return the input as output', function (done){
-    
+  it ('should return the input as output (py1)', function (done){
     run.run ('test/source_code/echo.py', 'python', 'teste1.txt').then(function (output){
-      
-      expect (output).to.have.property('stdout', 'teste1\n');
-      expect (output).to.have.property('status', 'ok');
-      expect (output).to.have.property('time');
-      expect (output.time).to.contains('ms');
-      
-      done();
+      testRun(output, "teste1", done);
+    });
+  });
+  
+  it ('should return the input as output (py2)', function (done){
+    run.run ('test/source_code/echo.py', 'python', 'teste2.txt').then(function (output){
+      testRun(output, "a sentence lorem ipsum", done);
+    });
+  });
+  
+  it ('should return the input as output (cpp1)', function (done){
+    run.run ('test/source_code/echo.cpp', 'c++', 'teste1.txt').then(function (output){
+      testRun(output, "teste1", done);
+    });
+  });
+  
+  it ('should return the input as output (cpp2)', function (done){
+    run.run ('test/source_code/echo.cpp', 'c++', 'teste2.txt').then(function (output){
+      testRun(output, "a sentence lorem ipsum", done);
+    });
+  });
+  
+  it ('should return the input as output (js1)', function (done){
+    run.run ('test/source_code/echo.js', 'node', 'teste1.txt').then(function (output){
+      testRun(output, "teste1", done);
+    });
+  });
+  
+  it ('should return the input as output (js2)', function (done){
+    run.run ('test/source_code/echo.js', 'node', 'teste2.txt').then(function (output){
+      testRun(output, "a sentence lorem ipsum", done);
+    });
+  });
+  
+  it ('should return the input as output (js3)', function (done){
+    run.run ('test/source_code/echo3.js', 'node', 'teste3.txt').then(function (output){
+      testRun(output, "pong\npong\npong", done);
     });
   });
   
   after (function (){
     execSync('rm -f teste*.txt');
+    execSync("rm main");
   });
 });


### PR DESCRIPTION
Javascript support is still experimental, but i tested it personally and it works. No need to write wrapper functions in code, it’s handled by runner. (because on code forces you can’t use console.log as output, you need to use print or write, and code will automatically use my own wrapper for readline function (took idea from sget library))